### PR TITLE
can now get all task status

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -3,6 +3,7 @@ const router = require('express').Router();
 const clientRoutes = require('./clientRoutes');
 const helperRoutes = require('./helperRoutes');
 const taskRoutes = require('./tasksRoutes');
+const taskStatusRoutes = require('./taskStatusRoutes');
 
 const landingPageRoutes = require('./landingPageRoutes');
 const registerRoutes = require('./registerRoutes');
@@ -10,6 +11,7 @@ const registerRoutes = require('./registerRoutes');
 router.use('/clients', clientRoutes);
 router.use('/helpers', helperRoutes);
 router.use('/task', taskRoutes);
+router.use('/taskStatus', taskStatusRoutes);
 
 router.use('/registerpage', registerRoutes);
 router.use('/landingpage', landingPageRoutes);

--- a/controllers/api/taskStatusRoutes.js
+++ b/controllers/api/taskStatusRoutes.js
@@ -1,9 +1,9 @@
 const router = require('express').Router();
-const { Client, Task, TaskStatus } = require('../../models');
+const { Task, TaskStatus } = require('../../models');
 
 router.get('/', async (req, res) => {
     try {
-        const statusData = await TaskStatus.findAll({include: [{ model: Client }, { model: Task }] });
+        const statusData = await TaskStatus.findAll({ include: Task });
         res.status(200).json(statusData);
     } catch (err) {
         res.status(500).json(err);

--- a/controllers/api/tasksRoutes.js
+++ b/controllers/api/tasksRoutes.js
@@ -1,10 +1,10 @@
 
 const router = require('express').Router();
-const { Task, Client } = require('../../models');
+const { Task, Client, TaskStatus } = require('../../models');
 
 router.get('/', async (req, res) => {
     try {
-      const taskData = await Task.findAll({include: Client});
+      const taskData = await Task.findAll({include: [{ model: Client}, {model: TaskStatus}] });
       res.status(200).json(taskData);
     } catch (err) {
         res.status(500).json(err);

--- a/models/index.js
+++ b/models/index.js
@@ -13,8 +13,15 @@ Client.hasMany(Task, {
 });
 
 TaskStatus.hasMany(Task, {
-    foreignKey: 'task_status_id',
+    foreignKey: 'status_id',
     onDelete: 'CASCADE'
-})
+});
+
+Task.belongsTo(TaskStatus, {
+    foreignKey: 'status_id',
+    onDelete: 'CASCADE'
+});
+
+
 
 module.exports = { Client, Helper, Task, TaskStatus };

--- a/models/taskStatus.js
+++ b/models/taskStatus.js
@@ -12,7 +12,7 @@ TaskStatus.init(
             primaryKey: true,
             autoIncrement: true
         },
-        task_status: {
+        status: {
             type: DataTypes.STRING,
             allowNull: false
         }
@@ -22,7 +22,7 @@ TaskStatus.init(
         timestamps: false,
         freezeTableName: true,
         underscored: true,
-        modelName: 'tasks'
+        modelName: 'taskStatus'
     }
 );
 

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -29,7 +29,7 @@ Task.init(
             allowNull: false
         },
             //Will probably make another table for this, so we can view tasks by status.  
-        task_status_id: {
+        status_id: {
             type: DataTypes.INTEGER,
             references: {
                 model: 'taskStatus',
@@ -43,7 +43,7 @@ Task.init(
                 model: 'client',
                 key: 'id'
             }
-        }
+        },
     },
     {
         //link to database connection

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -2,6 +2,7 @@ const sequelize = require('../config/connection');
 const seedClients = require('./client-seeds');
 const seedHelpers = require('./helpers-seeds');
 const seedTasks = require('./task-seeds');
+const seedTaskStatus = require('./status-seeds');
 
 
 const seedAll = async () => {
@@ -11,8 +12,11 @@ const seedAll = async () => {
     console.log('\n----- CLIENT SEEDED -----\n');
     await seedHelpers();
     console.log('\n----- HELPER SEEDED -----\n');
+    await seedTaskStatus();
+    console.log('\n----- TaskStatus SEEDED -----\n');
     await seedTasks();
     console.log('\n----- Task SEEDED -----\n');
+    
     
 
     process.exit(0);

--- a/seeds/status-seeds.js
+++ b/seeds/status-seeds.js
@@ -1,0 +1,17 @@
+const { TaskStatus } = require('../models');
+
+const statusData = [
+    {
+        status: 'Open',
+    },
+    {
+        status: 'Accepted',
+    },
+    {
+        status: 'Completed',
+    },
+];
+
+const seedStatus = () => TaskStatus.bulkCreate(statusData);
+
+module.exports = seedStatus;

--- a/seeds/task-seeds.js
+++ b/seeds/task-seeds.js
@@ -5,15 +5,14 @@ const taskData = [
         task: "Go for a walk",
         task_details: "I would like to go for a walk down my hallway. I have difficulty finding the motivation to just stand up and walk, but my doctor has warned me that I need to find some kind of exercise. My apartment is pet free. I do use a walker to help with my balance.",
         task_time: "Wednesday January 11th at 12:00pm",
-        task_status: "Accepted",
+        status_id: 2,
         client_id: 1,
-
     },
     {
         task: "Help with groceries",
         task_details: "I would like help shopping at the grocery store. I recently had shoulder surgery, and I can't lift heavy objects. I can go with you to the store to help pick things out. I just need help carrying the items to the car and into my home.",
         task_time: "Friday January 13th at 12:00pm",
-        task_status: "open",
+        status_id: 1,
         client_id: 2,
     },
     {
@@ -21,14 +20,14 @@ const taskData = [
         task: "Help with groceries",
         task_details: "I need some help with grocery shopping. I recently had knee surgery, and it would be helpful if someone could grab some groceries for me. I need milk, eggs, flour, sugar",
         task_time: "Monday January 23rd at 11:00am",
-        task_status: "open",
+        status_id: 1,
         client_id: 3,
     },
     {
         task: "Go for a walk",
-        task_details: "I would like to go for a walk in my neighborhood. I'm elderly, and I would like someone to accompany me and a walk, so I can feel a little safer.",
+        task_details: "I would like to go for a walk in my neighborhood. I'm elderly, and I would like someone to accompany me for a walk, so I can feel a little safer.",
         task_time: "Monday January 23rd at 12:00pm",
-        task_status: "completed",
+        status_id: 3,
         client_id: 4,
     },
     


### PR DESCRIPTION
This PR added code to the task status routes, models, and seeds. It is now possible to get all task statuses with their associated task and the clients who created them.