### PR TITLE
remove dotenv from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-.env
+
 .DS_Store


### PR DESCRIPTION
This PR removed .env from gitignore.